### PR TITLE
Hasura security

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ This application is part of [Mastering Next.js](https://masteringnextjs.com/).
 ```bash
 $ git clone https://github.com/leerob/daydrink.git
 $ cd leerob.io
+```
+
+Set GraphQL URL for Apollo Client by adding the following field to `.env` file.
+```
+GRAPHQL_URL=
+```
+
+```
 $ yarn
 $ yarn dev
 ```

--- a/graphql/apollo.js
+++ b/graphql/apollo.js
@@ -117,7 +117,7 @@ function createApolloClient(initialState = {}) {
     return new ApolloClient({
         ssrMode: typeof window === 'undefined',
         link: new HttpLink({
-            uri: 'https://daydrink.herokuapp.com/v1/graphql',
+            uri: process.env.GRAPHQL_URL,
             credentials: 'same-origin',
             fetch
         }),


### PR DESCRIPTION
If keeping Hasura GraphQL playground is intended then please ignore the PR.

Security Issue: Hasura's GraphQL URL is open and is not protected by a secret key.

Changes: Removed the direct use of GraphQL URL and instead added it to env variable. Also, updated the Readme with env variable instruction. 

Extra Suggestion:  Protect Hasura console by setting up an admin secret.